### PR TITLE
fix(agent): add POLKIT_ERROR_CANCELLED as return when polkit cancelled.

### DIFF
--- a/agent/polkitqt1-agent-session.cpp
+++ b/agent/polkitqt1-agent-session.cpp
@@ -150,6 +150,11 @@ void AsyncResult::setCompleted()
     d->result = nullptr;
 }
 
+void AsyncResult::setCancel(const QString &text){
+    Q_ASSERT(d->result);
+    g_simple_async_result_set_error(d->result, POLKIT_ERROR, POLKIT_ERROR_CANCELLED, "%s", text.toUtf8().data());
+}
+
 void AsyncResult::setError(const QString &text)
 {
     Q_ASSERT(d->result);

--- a/agent/polkitqt1-agent-session.h
+++ b/agent/polkitqt1-agent-session.h
@@ -44,6 +44,11 @@ public:
     void setCompleted();
 
     /**
+     * \brief Mark the action that is tied to this result as cancelled.
+     */
+    void setCancel(const QString &text);
+
+    /**
      * \brief Sets an error for the asynchronous result.
      * Method complete() must be called anyway.
      *


### PR DESCRIPTION
user cancel and password error should be divided sometimes